### PR TITLE
Helm Chart's Dependency update override issue fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     name: ${{ matrix.java }}
     strategy:
       matrix:
-        java: [11]
+        java: [11, 17]
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK ${{ matrix.java }}

--- a/src/main/scala/io/github/kiemlicz/shelm/ChartDownloader.scala
+++ b/src/main/scala/io/github/kiemlicz/shelm/ChartDownloader.scala
@@ -47,10 +47,10 @@ object ChartDownloader {
     }
   }
 
-  def extractArchive(uri: URI, unpackTo: File): Set[String] = {
+  def extractArchive(archiveUri: URI, unpackTo: File): Set[String] = {
     val topDirs = mutable.Set.empty[String]
-    open(uri.toURL.openStream())
-      .getOrElse(throw new IllegalStateException(s"Unable to download Helm Chart from: $uri"))
+    open(archiveUri.toURL.openStream())
+      .getOrElse(throw new IllegalStateException(s"Unable to extract Helm Chart from: $archiveUri"))
       .foreach {
         case (entry, is) =>
           try {

--- a/src/main/scala/io/github/kiemlicz/shelm/ChartLocation.scala
+++ b/src/main/scala/io/github/kiemlicz/shelm/ChartLocation.scala
@@ -119,6 +119,7 @@ case class ChartMappings(
 object ChartSettings {
   final val ChartYaml = "Chart.yaml"
   final val ValuesYaml = "values.yaml"
+  final val DependenciesPath = "charts"
 }
 
 case class ChartRepositoriesSettings(

--- a/src/sbt-test/shelm/dep-update-overrides/build.sbt
+++ b/src/sbt-test/shelm/dep-update-overrides/build.sbt
@@ -1,0 +1,80 @@
+import _root_.io.circe.{Json, yaml}
+import _root_.io.github.kiemlicz.shelm.HelmPlugin.autoImport.Helm
+import _root_.io.github.kiemlicz.shelm._
+import org.apache.commons.io.FileUtils
+
+import java.io.{FileInputStream, FileReader}
+import java.net.URI
+
+lazy val assertGeneratedValues = taskKey[Unit]("Assert packageValueOverrides")
+lazy val assertOverride = taskKey[Unit]("Assert overridden files")
+val cn = "kube-prometheus-stack"
+val cnVer = "27.2.0"
+val toOverride = "charts/kube-state-metrics/templates/servicemonitor.yaml"
+
+lazy val root = (project in file("."))
+  .enablePlugins(HelmPlugin)
+  .settings(
+    version := "0.1",
+    scalaVersion := "2.13.3",
+    Helm / chartSettings := Seq(
+      ChartSettings(
+        chartLocation = ChartLocation
+          .RemoteRepository(
+            ChartName("kube-prometheus-stack"),
+            URI.create("https://prometheus-community.github.io/helm-charts"),
+            ChartRepositorySettings.NoAuth,
+            Some(cnVer)
+          ),
+      )
+    ),
+    Helm / chartMappings := { s =>
+      ChartMappings(
+        s,
+        destination = target.value,
+        chartUpdate = u => u.copy(version = s"${u.version}+extra"),
+        includeFiles = Seq(
+          file("config") / "kube-state-servicemonitor.yaml" -> toOverride
+        ),
+        yamlsToMerge = Seq(
+          file("values-override.yaml") -> "values.yaml"
+        )
+      )
+    }
+  )
+
+assertGeneratedValues := {
+  val tempChartValues = target.value / s"$cn-0" / cn / "values.yaml"
+  yaml.parser.parse(new FileReader(tempChartValues)) match {
+    case Right(json) =>
+      val cursor = json.hcursor
+      val r = for {
+        ksm <- cursor.get[Json]("kubeStateMetrics")
+        extraFlag <- ksm.hcursor.get[String]("extraFlag")
+      } yield extraFlag == "something"
+      assert(r.getOrElse(false), "Test fail, wrong values.yaml settings detected")
+    case Left(err: Throwable) => throw err
+  }
+}
+
+assertOverride := {
+  val overriddenYaml = target.value / s"$cn-0" / cn / toOverride
+  val packagedChart = target.value / s"$cn-$cnVer+extra.tgz"
+  val unpacked = target.value / s"toAssert"
+  val fileToAssert = target.value / s"toAssert" / cn / toOverride
+  val found = IO.readLines(overriddenYaml).filter(_.contains("caFile: /etc/prom-certs/root-cert.pem"))
+  assert(found.length == 2, "Expected 'caFile: /etc/prom-certs/root-cert.pem' two times")
+
+  ChartDownloader.open(new FileInputStream(packagedChart))
+    .getOrElse(throw new IllegalStateException(s"Unable to open Helm Chart: $packagedChart"))
+    .foreach {
+      case (entry, is) =>
+        try {
+          val archiveEntry = unpacked / entry.getName
+          IO.write(archiveEntry, IO.readBytes(is))
+        } finally {
+          is.close()
+        }
+    }
+  assert(FileUtils.contentEquals(file("config") / "kube-state-servicemonitor.yaml", fileToAssert), "config/kube-state-servicemonitor.yaml and packaged version differs")
+}

--- a/src/sbt-test/shelm/dep-update-overrides/config/kube-state-servicemonitor.yaml
+++ b/src/sbt-test/shelm/dep-update-overrides/config/kube-state-servicemonitor.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.prometheus.monitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "kube-state-metrics.fullname" . }}
+  namespace: {{ template "kube-state-metrics.namespace" . }}
+  labels:
+    {{- include "kube-state-metrics.labels" . | indent 4 }}
+  {{- with .Values.prometheus.monitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  jobLabel: {{ default "app.kubernetes.io/name" .Values.prometheus.monitor.jobLabel }}
+  selector:
+    matchLabels:
+      {{- include "kube-state-metrics.selectorLabels" . | indent 6 }}
+  endpoints:
+    - port: http
+    {{- if .Values.istio.mtls.enabled }}
+      scheme: https
+      tlsConfig:
+        caFile: /etc/prom-certs/root-cert.pem
+        certFile: /etc/prom-certs/cert-chain.pem
+        insecureSkipVerify: false
+        keyFile: /etc/prom-certs/key.pem
+    {{- end }}
+    {{- if .Values.prometheus.monitor.interval }}
+      interval: {{ .Values.prometheus.monitor.interval }}
+    {{- end }}
+    {{- if .Values.prometheus.monitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.prometheus.monitor.scrapeTimeout }}
+    {{- end }}
+    {{- if .Values.prometheus.monitor.proxyUrl }}
+      proxyUrl: {{ .Values.prometheus.monitor.proxyUrl}}
+    {{- end }}
+    {{- if .Values.prometheus.monitor.honorLabels }}
+      honorLabels: true
+    {{- end }}
+    {{- if .Values.prometheus.monitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml .Values.prometheus.monitor.metricRelabelings | nindent 8 }}
+    {{- end }}
+    {{- if .Values.prometheus.monitor.relabelings }}
+      relabelings:
+        {{- toYaml .Values.prometheus.monitor.relabelings | nindent 8 }}
+    {{- end }}
+  {{- if .Values.selfMonitor.enabled }}
+    - port: metrics
+    {{- if .Values.istio.mtls.enabled }}
+      scheme: https
+      tlsConfig:
+        caFile: /etc/prom-certs/root-cert.pem
+        certFile: /etc/prom-certs/cert-chain.pem
+        insecureSkipVerify: false
+        keyFile: /etc/prom-certs/key.pem
+    {{- end }}
+    {{- if .Values.prometheus.monitor.interval }}
+      interval: {{ .Values.prometheus.monitor.interval }}
+    {{- end }}
+    {{- if .Values.prometheus.monitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.prometheus.monitor.scrapeTimeout }}
+    {{- end }}
+    {{- if .Values.prometheus.monitor.proxyUrl }}
+      proxyUrl: {{ .Values.prometheus.monitor.proxyUrl}}
+    {{- end }}
+    {{- if .Values.prometheus.monitor.honorLabels }}
+      honorLabels: true
+    {{- end }}
+    {{- if .Values.prometheus.monitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml .Values.prometheus.monitor.metricRelabelings | nindent 8 }}
+    {{- end }}
+    {{- if .Values.prometheus.monitor.relabelings }}
+      relabelings:
+        {{- toYaml .Values.prometheus.monitor.relabelings | nindent 8 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/src/sbt-test/shelm/dep-update-overrides/project/build.properties
+++ b/src/sbt-test/shelm/dep-update-overrides/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.5.7

--- a/src/sbt-test/shelm/dep-update-overrides/project/deps.sbt
+++ b/src/sbt-test/shelm/dep-update-overrides/project/deps.sbt
@@ -1,0 +1,2 @@
+// to assert that unpacked artifact is properly built
+libraryDependencies += "commons-io" % "commons-io" % "2.11.0"

--- a/src/sbt-test/shelm/dep-update-overrides/project/plugins.sbt
+++ b/src/sbt-test/shelm/dep-update-overrides/project/plugins.sbt
@@ -1,0 +1,7 @@
+sys.props.get("plugin.version") match {
+  case Some(v) => addSbtPlugin("io.github.kiemlicz" % "shelm" % v)
+  case _ => sys.error(
+    """|The system property 'plugin.version' is not defined.
+       |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+  )
+}

--- a/src/sbt-test/shelm/dep-update-overrides/test
+++ b/src/sbt-test/shelm/dep-update-overrides/test
@@ -5,6 +5,7 @@
 
 $ exists target/kube-prometheus-stack-27.2.0+extra.tgz
 $ exists target/kube-prometheus-stack-0/kube-prometheus-stack/Chart.yaml
+$ exists target/kube-prometheus-stack-0/kube-prometheus-stack/charts/kube-state-metrics/Chart.yaml
 
 > assertGeneratedValues
 > assertOverride

--- a/src/sbt-test/shelm/dep-update-overrides/test
+++ b/src/sbt-test/shelm/dep-update-overrides/test
@@ -1,0 +1,14 @@
+# ensure clean state
+> clean
+
+> helm:packagesBin
+
+$ exists target/kube-prometheus-stack-27.2.0+extra.tgz
+$ exists target/kube-prometheus-stack-0/kube-prometheus-stack/Chart.yaml
+
+> assertGeneratedValues
+> assertOverride
+
+> clean
+$ absent target/kube-prometheus-stack-27.2.0+extra.tgz
+$ absent target/kube-prometheus-stack-0/kube-prometheus-stack/Chart.yaml

--- a/src/sbt-test/shelm/dep-update-overrides/values-override.yaml
+++ b/src/sbt-test/shelm/dep-update-overrides/values-override.yaml
@@ -1,0 +1,7 @@
+kubeStateMetrics:
+  extraFlag: "something"
+
+kube-state-metrics:
+  istio:
+    mtls:
+      enabled: true

--- a/src/sbt-test/shelm/simple/test
+++ b/src/sbt-test/shelm/simple/test
@@ -7,7 +7,7 @@ $ exists target/simple-chart-0.3.0-rc.1+some-meta-info-2021.01.01-even.more.124.
 $ exists target/simple-chart-0/simple-chart/Chart.yaml
 $ exists target/simple-chart-0/simple-chart/values.yaml
 $ exists target/simple-chart-0/simple-chart/templates/service.yaml
-$ exists target/simple-chart-0/simple-chart/charts/redis-10.5.7.tgz
+$ exists target/simple-chart-0/simple-chart/charts/redis/Chart.yaml
 
 > assertArtifacts
 

--- a/src/sbt-test/shelm/simple/test
+++ b/src/sbt-test/shelm/simple/test
@@ -8,6 +8,8 @@ $ exists target/simple-chart-0/simple-chart/Chart.yaml
 $ exists target/simple-chart-0/simple-chart/values.yaml
 $ exists target/simple-chart-0/simple-chart/templates/service.yaml
 $ exists target/simple-chart-0/simple-chart/charts/redis/Chart.yaml
+# now it is always unpacked
+$ absent target/simple-chart-0/simple-chart/charts/redis-10.5.7.tgz
 
 > assertArtifacts
 


### PR DESCRIPTION
Early `helm dependency update` to prevent overriding of the `includeFiles` by the dependencies themselves 