### PR TITLE
Transform chart dependencies before performing "helm dependency update"

### DIFF
--- a/src/main/scala/io/github/kiemlicz/shelm/Chart.scala
+++ b/src/main/scala/io/github/kiemlicz/shelm/Chart.scala
@@ -41,6 +41,7 @@ object Chart {
     keywords <- c.get[Option[List[String]]]("keywords")
     home <- c.get[Option[URI]]("home")
     sources <- c.get[Option[List[URI]]]("sources")
+    // FIXME: If dependencies are defined in `requirements.yaml` instead of in `Chart.yaml` then they won't be detected
     dependencies <- c.get[Option[List[ChartDependency]]]("dependencies")
     maintainers <- c.get[Option[List[ChartMaintainer]]]("maintainers")
     icon <- c.get[Option[URI]]("icon")

--- a/src/main/scala/io/github/kiemlicz/shelm/ChartLocation.scala
+++ b/src/main/scala/io/github/kiemlicz/shelm/ChartLocation.scala
@@ -102,7 +102,7 @@ case class ChartSettings(
   * @param includeFiles     list of file mappings which will be present in Chart (sbt-native-packager-a-like)
   * @param yamlsToMerge     list of yaml files that will be merged with currently present in Chart or added
   * @param valueOverrides   programmatic overrides (takes priority over `yamlsToMerge`)
-  * @param dependencyUpdate perform `helm dependency update` before `helm package` after transforming the dependencies list
+  * @param dependencyUpdate perform `helm dependency update` before `helm package` (default: true)
   * @param fatalLint        fail if `helm lint` fails (default: true)
   */
 case class ChartMappings(
@@ -112,7 +112,7 @@ case class ChartMappings(
   includeFiles: Seq[(File, String)] = Seq.empty,
   yamlsToMerge: Seq[(File, String)] = Seq.empty,
   valueOverrides: Option[Json] => Seq[Json] = _ => Seq.empty,
-  dependencyUpdate: DependencyUpdateSettings = DependencyUpdateSettings.UpdateAll,
+  dependencyUpdate: Boolean = true,
   fatalLint: Boolean = true
 )
 
@@ -120,17 +120,6 @@ object ChartSettings {
   final val ChartYaml = "Chart.yaml"
   final val ValuesYaml = "values.yaml"
   final val DependenciesPath = "charts"
-}
-
-sealed trait DependencyUpdateSettings
-
-object DependencyUpdateSettings {
-  object DontUpdate extends DependencyUpdateSettings
-
-  case class TransformAndUpdate(dependenciesTransform: List[ChartDependency] => List[ChartDependency])
-    extends DependencyUpdateSettings
-
-  val UpdateAll: DependencyUpdateSettings = TransformAndUpdate(identity)
 }
 
 case class PackagedChartInfo(chartName: ChartName, version: SemVer2, location: File)

--- a/src/main/scala/io/github/kiemlicz/shelm/ChartLocation.scala
+++ b/src/main/scala/io/github/kiemlicz/shelm/ChartLocation.scala
@@ -102,7 +102,7 @@ case class ChartSettings(
   * @param includeFiles     list of file mappings which will be present in Chart (sbt-native-packager-a-like)
   * @param yamlsToMerge     list of yaml files that will be merged with currently present in Chart or added
   * @param valueOverrides   programmatic overrides (takes priority over `yamlsToMerge`)
-  * @param dependencyUpdate perform `helm dependency update` before `helm package` (default: true)
+  * @param dependencyUpdate perform `helm dependency update` before `helm package` after transforming the dependencies list
   * @param fatalLint        fail if `helm lint` fails (default: true)
   */
 case class ChartMappings(
@@ -112,7 +112,7 @@ case class ChartMappings(
   includeFiles: Seq[(File, String)] = Seq.empty,
   yamlsToMerge: Seq[(File, String)] = Seq.empty,
   valueOverrides: Option[Json] => Seq[Json] = _ => Seq.empty,
-  dependencyUpdate: Boolean = true,
+  dependencyUpdate: DependencyUpdateSettings = DependencyUpdateSettings.UpdateAll,
   fatalLint: Boolean = true
 )
 
@@ -122,9 +122,15 @@ object ChartSettings {
   final val DependenciesPath = "charts"
 }
 
-case class ChartRepositoriesSettings(
-  repositories: Seq[ChartRepository] = Seq.empty,
-  update: Boolean = false,
-)
+sealed trait DependencyUpdateSettings
+
+object DependencyUpdateSettings {
+  object DontUpdate extends DependencyUpdateSettings
+
+  case class TransformAndUpdate(dependenciesTransform: List[ChartDependency] => List[ChartDependency])
+    extends DependencyUpdateSettings
+
+  val UpdateAll: DependencyUpdateSettings = TransformAndUpdate(identity)
+}
 
 case class PackagedChartInfo(chartName: ChartName, version: SemVer2, location: File)

--- a/src/sbt-test/shelm/add-repository/build.sbt
+++ b/src/sbt-test/shelm/add-repository/build.sbt
@@ -1,3 +1,7 @@
+import _root_.io.circe.{Json, yaml}
+import _root_.io.github.kiemlicz.shelm.HelmPlugin.autoImport.Helm
+import _root_.io.github.kiemlicz.shelm._
+
 import java.io.FileReader
 import java.net.URI
 

--- a/src/sbt-test/shelm/add-repository/build.sbt
+++ b/src/sbt-test/shelm/add-repository/build.sbt
@@ -36,7 +36,7 @@ lazy val root = (project in file("."))
             )
           )
         ),
-        DependencyUpdateSettings.UpdateAll,
+        true,
         false
       )
     }

--- a/src/sbt-test/shelm/add-repository/build.sbt
+++ b/src/sbt-test/shelm/add-repository/build.sbt
@@ -1,7 +1,3 @@
-import _root_.io.circe.{Json, yaml}
-import _root_.io.github.kiemlicz.shelm.HelmPlugin.autoImport.Helm
-import _root_.io.github.kiemlicz.shelm._
-
 import java.io.FileReader
 import java.net.URI
 
@@ -36,7 +32,7 @@ lazy val root = (project in file("."))
             )
           )
         ),
-        true,
+        DependencyUpdateSettings.UpdateAll,
         false
       )
     }

--- a/src/sbt-test/shelm/duplicated/build.sbt
+++ b/src/sbt-test/shelm/duplicated/build.sbt
@@ -46,7 +46,7 @@ lazy val root = (project in file("."))
           ))),
           sources = Some(new URI("https://example/com") :: chart.sources.toList.flatten)
         ),
-        dependencyUpdate = DependencyUpdateSettings.DontUpdate
+        dependencyUpdate = false
       )
     }
   )

--- a/src/sbt-test/shelm/duplicated/build.sbt
+++ b/src/sbt-test/shelm/duplicated/build.sbt
@@ -45,7 +45,8 @@ lazy val root = (project in file("."))
             url = None
           ))),
           sources = Some(new URI("https://example/com") :: chart.sources.toList.flatten)
-        )
+        ),
+        dependencyUpdate = DependencyUpdateSettings.DontUpdate
       )
     }
   )


### PR DESCRIPTION
Adding a new feature: Allow transformation chart dependencies before performing "helm dependency update"

This is intended to allow workarounds for https://github.com/bitnami/charts/issues/10539.

Problem I'm trying to solve is as follows:

1. I use an pre-2022 Bitnami chart
2. I try simply swap the repo URL to the pre-2022 one and build the chart
3. Fetching chart dependencies fails because the chart depends on other pre-2022 Bitnami charts
4. I don't want to disable the dependency update, because I do need to use the dependent charts
5. I need to transform the dependencies, so that the dependencies use the pre-2022 Bitnami repo